### PR TITLE
Fix ldf_message.payload column type (text, not varchar 255)

### DIFF
--- a/src/controllers/ldf_receiver_controller.erl
+++ b/src/controllers/ldf_receiver_controller.erl
@@ -17,8 +17,12 @@ create_message(#{json := #{<<"id">> := MessageId} = Json}) ->
     logger:debug("message: ~p~n", [Message]),
     EncodedMessage = encode(Message),
     logger:debug("Encoded message: ~p~n", [EncodedMessage]),
-    ok = ldf_db:add_message(EncodedMessage, MessageId),
-    ldf_www_controller:publish_message(MessageId, EncodedMessage),
+    case ldf_db:add_message(EncodedMessage, MessageId) of
+        ok ->
+            ldf_www_controller:publish_message(MessageId, EncodedMessage);
+        {error, Reason} ->
+            logger:error("failed to store message ~s: ~p", [MessageId, Reason])
+    end,
     {status, 200}.
 
 get_message(#{parsed_qs := ParsedQS}) ->

--- a/src/migrations/m20260624171034_alter_ldf_message.erl
+++ b/src/migrations/m20260624171034_alter_ldf_message.erl
@@ -1,0 +1,17 @@
+-module(m20260624171034_alter_ldf_message).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [{alter_table, ~"ldf_message", [
+        {modify_column, payload, text}
+    ]}].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [{alter_table, ~"ldf_message", [
+        {modify_column, payload, string}
+    ]}].

--- a/src/schemas/ldf_message.erl
+++ b/src/schemas/ldf_message.erl
@@ -10,6 +10,6 @@ table() -> ~"ldf_message".
 fields() -> [
     #kura_field{name = id, type = id, primary_key = true},
     #kura_field{name = message_id, type = uuid, nullable = false},
-    #kura_field{name = payload, type = string},
+    #kura_field{name = payload, type = text},
     #kura_field{name = content_length, type = string}
 ].


### PR DESCRIPTION
Real chatli-forwarded messages crashed `create_message` with `value too long for type character varying(255)`: kura's `string` type is `VARCHAR(255)`, but `payload` stores the entire encoded message JSON (with sender_info/user_agent), which exceeds 255 chars. The pre-kura column was unbounded `VARCHAR`.

- `ldf_message` schema: `payload` `string` -> `text` (TEXT) + generated alter migration (applies in place on boot, no data loss).
- Harden `create_message`: a DB error now logs instead of badmatch-crashing the request.

Verified end-to-end: a 425-char message inserts and streams to `/www/receiver` (200), no crash.