### PR TITLE
Receiver: clickable attachment links, clean display, dedup SSE init

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -37,6 +37,7 @@
     ]},
     {ldf, [
         {chatli_path, <<"http://chatli:8090/v1">>},
+        {chatli_public_path, <<"http://localhost:8090/v1">>},
         {ldf_callback, <<"http://ldf:8095/receiver">>}
     ]}
     %% Please change your app.src-file instead if you intend to add app-specific configurations

--- a/config/sys.docker.config
+++ b/config/sys.docker.config
@@ -38,6 +38,7 @@
     ]},
     {ldf, [
         {chatli_path, <<"http://localhost:8090/v1">>},
+        {chatli_public_path, <<"http://localhost:8090/v1">>},
         {ldf_callback, <<"http://localhost:8095/receiver">>}
     ]}
     %% Please change your app.src-file instead if you intend to add app-specific configurations

--- a/priv/assets/css/ldf.css
+++ b/priv/assets/css/ldf.css
@@ -126,6 +126,8 @@ tbody tr:last-child td { border-bottom: none; }
 /* live message feed */
 .feed td:first-child { color: var(--faint); white-space: nowrap; width: 1%; }
 .msg { font-family: var(--mono); color: var(--text); word-break: break-word; }
+.msg a { color: var(--live); text-decoration: none; border-bottom: 1px dotted var(--live-dim); word-break: break-all; }
+.msg a:hover { border-bottom-style: solid; }
 @keyframes flashin {
   0% { background: rgba(46,230,166,.16); transform: translateY(-3px); opacity: 0; }
   100% { background: transparent; transform: none; opacity: 1; }

--- a/src/controllers/ldf_receiver_controller.erl
+++ b/src/controllers/ldf_receiver_controller.erl
@@ -8,7 +8,7 @@ create_message(#{json := #{<<"id">> := MessageId} = Json}) ->
     Message =
         case Json of
             #{<<"payload">> := #{<<"url">> := Url} = Payload} ->
-                {ok, ChatliPath} = application:get_env(ldf, chatli_path),
+                {ok, ChatliPath} = application:get_env(ldf, chatli_public_path),
                 Payload2 = maps:update(<<"url">>, <<ChatliPath/binary, "/", Url/binary>>, Payload),
                 maps:update(<<"payload">>, Payload2, Json);
             _ ->

--- a/src/controllers/ldf_www_controller.erl
+++ b/src/controllers/ldf_www_controller.erl
@@ -106,12 +106,12 @@ feed_empty() ->
 %% The stored payload is the full encoded message; show its inner payload -
 %% an attachment URL becomes a clickable link, plain text stays text.
 row_vars(Ref, StoredPayload, New) ->
-    case display(StoredPayload) of
+    case display_payload(StoredPayload) of
         {link, Url} -> [{ref, Ref}, {new, New}, {link, Url}, {text, ~""}];
         {text, Text} -> [{ref, Ref}, {new, New}, {link, false}, {text, Text}]
     end.
 
-display(StoredPayload) ->
+display_payload(StoredPayload) ->
     try json:decode(StoredPayload) of
         #{~"payload" := #{~"url" := Url}} when is_binary(Url) -> {link, public_url(Url)};
         #{~"payload" := Text} when is_binary(Text) -> {text, Text};

--- a/src/controllers/ldf_www_controller.erl
+++ b/src/controllers/ldf_www_controller.erl
@@ -78,7 +78,7 @@ submit_history(Req0) ->
 %% --- published by the message API on each intercepted message -------------
 
 publish_message(MessageId, Payload) ->
-    Row = render(message_row_dtl, [{ref, ref(MessageId)}, {payload, Payload}, {new, true}]),
+    Row = render(message_row_dtl, row_vars(ref(MessageId), Payload, true)),
     datastar_nova:publish(?MESSAGES, [
         datastar:patch_elements(~"", #{selector => ~"#feed-empty", mode => remove}),
         datastar:patch_elements(Row, #{selector => ~"#messages", mode => append})
@@ -86,21 +86,50 @@ publish_message(MessageId, Payload) ->
 
 %% --- helpers --------------------------------------------------------------
 
+%% Replace (not append) the whole list on connect, so reconnects re-sync
+%% instead of duplicating the batch. Live messages still append.
 message_init([]) ->
-    [];
+    [datastar:patch_elements(feed_empty(), #{selector => ~"#messages", mode => inner})];
 message_init(Msgs) ->
     Rows = [
-        render(message_row_dtl, [
-            {ref, ref(maps:get(message_id, M, ~""))},
-            {payload, maps:get(payload, M, ~"")},
-            {new, false}
-        ])
+        render(
+            message_row_dtl,
+            row_vars(ref(maps:get(message_id, M, ~"")), maps:get(payload, M, ~""), false)
+        )
      || M <- Msgs
     ],
-    [
-        datastar:patch_elements(~"", #{selector => ~"#feed-empty", mode => remove}),
-        datastar:patch_elements(Rows, #{selector => ~"#messages", mode => append})
-    ].
+    [datastar:patch_elements(Rows, #{selector => ~"#messages", mode => inner})].
+
+feed_empty() ->
+    ~"<tr id=\"feed-empty\"><td colspan=\"2\" class=\"empty\">Awaiting interception</td></tr>".
+
+%% The stored payload is the full encoded message; show its inner payload -
+%% an attachment URL becomes a clickable link, plain text stays text.
+row_vars(Ref, StoredPayload, New) ->
+    case display(StoredPayload) of
+        {link, Url} -> [{ref, Ref}, {new, New}, {link, Url}, {text, ~""}];
+        {text, Text} -> [{ref, Ref}, {new, New}, {link, false}, {text, Text}]
+    end.
+
+display(StoredPayload) ->
+    try json:decode(StoredPayload) of
+        #{~"payload" := #{~"url" := Url}} when is_binary(Url) -> {link, public_url(Url)};
+        #{~"payload" := Text} when is_binary(Text) -> {text, Text};
+        _ -> {text, StoredPayload}
+    catch
+        _:_ -> {text, StoredPayload}
+    end.
+
+%% Rewrite an attachment URL onto the browser-reachable chatli host,
+%% regardless of which host got baked in when it was stored.
+public_url(Url) ->
+    case binary:split(Url, ~"/chat/") of
+        [_Host, Rest] ->
+            {ok, Public} = application:get_env(ldf, chatli_public_path),
+            <<Public/binary, "/chat/", Rest/binary>>;
+        _ ->
+            Url
+    end.
 
 broadcast_listeners() ->
     {ok, Listeners} = ldf_db:get_all_li(),

--- a/src/views/message_row.dtl
+++ b/src/views/message_row.dtl
@@ -1,1 +1,1 @@
-<tr{% if new %} class="new"{% endif %}><td class="mono-id">{{ ref }}</td><td class="msg">{{ payload }}</td></tr>
+<tr{% if new %} class="new"{% endif %}><td class="mono-id">{{ ref }}</td><td class="msg">{% if link %}<a href="{{ link }}" target="_blank" rel="noopener">{{ link }}</a>{% else %}{{ text }}{% endif %}</td></tr>


### PR DESCRIPTION
Addresses three issues seen while testing the live receiver feed:

1. **Attachment links unreachable from the browser** - the URL used the internal `chatli:8090` host. Added `chatli_public_path` (browser-facing) for building attachment URLs, and normalize stored URLs onto that host at display time so existing rows work too.
2. **Links not clickable** - the feed showed the raw stored JSON. Now it shows the message's inner payload as text, and attachment messages render a clickable `<a>` link.
3. **Same batch repeating** - `message_init` appended the full list on every SSE (re)connect, so a reconnect duplicated everything. Now it replaces (`#messages` inner) - idempotent re-sync; live messages still append.

Verified in headless Chrome: text rows show clean payload, attachment row is a clickable `localhost:8090` link, no duplicate rows across the held SSE.