### PR TITLE
feat: clarify history flow + local-time from-picker

### DIFF
--- a/priv/assets/css/ldf.css
+++ b/priv/assets/css/ldf.css
@@ -97,6 +97,8 @@ input[type="datetime-local"] { color-scheme: dark; }
 input[type=text]:focus, input[type="datetime-local"]:focus { outline: none; border-color: var(--live-dim); box-shadow: 0 0 0 3px rgba(46,230,166,.12); }
 input::placeholder { color: var(--faint); }
 .hint { color: var(--faint); font-size: 11px; margin: 8px 0 0; }
+.hint a { color: var(--live); text-decoration: none; border-bottom: 1px dotted var(--live-dim); }
+.hint a:hover { border-bottom-style: solid; }
 
 .btn {
   font-family: var(--mono); font-size: 12px; letter-spacing: .1em; text-transform: uppercase;

--- a/src/controllers/ldf_www_controller.erl
+++ b/src/controllers/ldf_www_controller.erl
@@ -67,11 +67,11 @@ remove_listener(#{bindings := #{~"callbackid" := CallbackId}}) ->
 submit_history(Req0) ->
     case datastar_nova:read_signals(Req0) of
         {{ok, #{~"type" := Type, ~"value" := Value} = Signals}, _Req} when Value =/= ~"" ->
-            Timestamp = ldf_format:datetime_to_ms(maps:get(~"timestamp", Signals, ~"")),
+            Timestamp = maps:get(~"timestamp_ms", Signals, 0),
             ldf_srv:get_history(
                 thoas:encode(#{type => Type, value => Value, timestamp => Timestamp})
             ),
-            status_patch(~"Request submitted.");
+            status_patch(~"Request submitted - matching messages appear in the Receiver tab.");
         _ ->
             status_patch(~"Target type and value are required.")
     end.

--- a/src/ldf_format.erl
+++ b/src/ldf_format.erl
@@ -1,6 +1,6 @@
 -module(ldf_format).
 
--export([pretty_xml/1, html_escape/1, datetime_to_ms/1]).
+-export([pretty_xml/1, html_escape/1]).
 
 pretty_xml(Xml) ->
     Spaced = binary:replace(Xml, ~"><", ~">\n<", [global]),
@@ -38,20 +38,3 @@ html_escape(Bin) ->
     Amp = binary:replace(Bin, ~"&", ~"&amp;", [global]),
     Lt = binary:replace(Amp, ~"<", ~"&lt;", [global]),
     binary:replace(Lt, ~">", ~"&gt;", [global]).
-
-datetime_to_ms(
-    <<Y:4/binary, "-", Mo:2/binary, "-", D:2/binary, "T", H:2/binary, ":", Mi:2/binary, Rest/binary>>
-) ->
-    Seconds =
-        case Rest of
-            <<":", S:2/binary>> -> binary_to_integer(S);
-            _ -> 0
-        end,
-    DateTime = {
-        {binary_to_integer(Y), binary_to_integer(Mo), binary_to_integer(D)},
-        {binary_to_integer(H), binary_to_integer(Mi), Seconds}
-    },
-    Epoch = 62167219200,
-    (calendar:datetime_to_gregorian_seconds(DateTime) - Epoch) * 1000;
-datetime_to_ms(_) ->
-    0.

--- a/src/views/history.dtl
+++ b/src/views/history.dtl
@@ -4,7 +4,7 @@
 <h1 class="page-title">History submission</h1>
 <p class="page-sub">Replay stored messages for a target as historic interception, from a given timestamp.</p>
 
-<div class="panel">
+<div class="panel" data-signals="{timestamp_ms: 0}">
   <div class="panel-head"><h2>Submit history request</h2></div>
   <div class="panel-body">
     <div class="row">
@@ -13,10 +13,10 @@
       <input type="text" data-bind:value placeholder="target@example.com" data-on:keydown="evt.key === 'Enter' && @post('/www/history')">
     </div>
     <div class="row" style="margin-top:12px">
-      <input type="datetime-local" step="1" lang="sv-SE" data-bind:timestamp>
+      <input type="datetime-local" step="1" lang="sv-SE" data-bind:timestamp data-on:change="$timestamp_ms = el.value ? (new Date(el.value).getTime() || 0) : 0">
       <button class="btn" data-on:click="@post('/www/history')">Submit request</button>
     </div>
-    <p class="hint">Replays messages from this point in time onward (UTC).</p>
+    <p class="hint">Requires an active listener for this target &mdash; add one on the <a href="/www/admin">Listeners</a> tab first. Matching messages replay into the <a href="/www/receiver">Receiver</a> tab, from the chosen local time onward.</p>
     <div id="hist-status" style="margin-top:16px;color:var(--dim);font-size:12.5px">&nbsp;</div>
   </div>
 </div>

--- a/test/ldf_format_tests.erl
+++ b/test/ldf_format_tests.erl
@@ -16,18 +16,3 @@ pretty_xml_with_prolog_test() ->
 
 html_escape_test() ->
     ?assertEqual(~"&lt;a&gt;&amp;b", ldf_format:html_escape(~"<a>&b")).
-
-datetime_to_ms_with_seconds_test() ->
-    Expected =
-        (calendar:datetime_to_gregorian_seconds({{2024, 6, 25}, {15, 0, 30}}) - 62167219200) *
-            1000,
-    ?assertEqual(Expected, ldf_format:datetime_to_ms(~"2024-06-25T15:00:30")).
-
-datetime_to_ms_without_seconds_test() ->
-    Expected =
-        (calendar:datetime_to_gregorian_seconds({{2024, 6, 25}, {15, 0, 0}}) - 62167219200) *
-            1000,
-    ?assertEqual(Expected, ldf_format:datetime_to_ms(~"2024-06-25T15:00")).
-
-datetime_to_ms_empty_test() ->
-    ?assertEqual(0, ldf_format:datetime_to_ms(~"")).


### PR DESCRIPTION
Follow-up from testing: history submits but nothing appeared, because replayed messages are delivered through the listener callback to the **Receiver** tab — and only if a listener exists for the target. This makes that explicit and fixes the time interpretation.

## Guidance
- The History page now states it requires an active listener (links to the Listeners tab) and that matching messages replay into the Receiver tab.
- Status message after submit points at the Receiver tab.

## Local time
- The `datetime-local` picker is now interpreted in the **browser's local timezone**: converted to epoch ms client-side (`new Date(value).getTime()`) into a `timestamp_ms` signal, which `submit_history` forwards directly.
- Removed the server-side UTC parse (`ldf_format:datetime_to_ms`) and its tests — the chosen time now means local wall-clock time, as expected.

No change to the delivery model (still the realistic LI callback → Receiver flow).

Local checks: `rebar3 fmt --check`, `xref`, `dialyzer`, `eunit` (3/3) clean.